### PR TITLE
Fix attribute value selector example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ DOM/Composite component, not actual DOM attributes being rendered.
 
 ```javascript
 $R(component).find('[target="_blank"]');
-$R(component, '[href=http://www.github.com/]');
+$R(component, '[href="http://www.github.com/"]');
 ```
 
 **Supported Operators**:


### PR DESCRIPTION
> _Note:_ All values _must_ be provided as double-quoted strings. `[att="val"]` is
> valid, but `[att=val]` and `[att='val']` are not.
