### PR TITLE
Add text method to retrieve inner text

### DIFF
--- a/rquery.js
+++ b/rquery.js
@@ -283,6 +283,12 @@
     }
   };
 
+  rquery.prototype.text = function () {
+    return this.components.reduce(function(prev, curr) {
+      return prev += curr.getDOMNode().innerText || curr.getDOMNode().textContent;
+    }, '')
+  };
+
   var EVENT_NAMES = [
     // clipboard events
     'copy', 'cut', 'paste',

--- a/rquery.js
+++ b/rquery.js
@@ -284,9 +284,9 @@
   };
 
   rquery.prototype.text = function () {
-    return _.reduce(this.components, function(memo, comp) {
-      return memo += comp.getDOMNode().innerText || comp.getDOMNode().textContent;
-    }, '')
+    return _.map(this.components, function(component) {
+      return component.getDOMNode().innerText || component.getDOMNode().textContent;
+    }).join('');
   };
 
   var EVENT_NAMES = [

--- a/rquery.js
+++ b/rquery.js
@@ -284,8 +284,8 @@
   };
 
   rquery.prototype.text = function () {
-    return this.components.reduce(function(prev, curr) {
-      return prev += curr.getDOMNode().innerText || curr.getDOMNode().textContent;
+    return _.reduce(this.components, function(memo, comp) {
+      return memo += comp.getDOMNode().innerText || comp.getDOMNode().textContent;
     }, '')
   };
 

--- a/test/rquery.spec.js
+++ b/test/rquery.spec.js
@@ -46,3 +46,33 @@ describe('#get', function () {
     });
   });
 });
+
+describe('#text', function () {
+  var TestUtils = React.addons.TestUtils;
+
+  before(function () {
+    this.reactClass = React.createClass({
+      render: function () {
+        var p1 = React.createElement('p', null, 'Te'),
+            p2 = React.createElement('p', null, 'xt');
+
+        return React.createElement('div', null, p1, p2);
+      }
+    });
+
+    this.component = TestUtils.renderIntoDocument(React.createElement(this.reactClass));
+    this.$r = $R(this.component).findComponent(this.reactClass);
+  });
+
+  context('when called on multiple components', function() {
+    it('returns the inner text of the selected components', function() {
+      expect(this.$r.find('p').text()).to.eq('Text');
+    });
+  });
+
+  context('when called on single component', function() {
+    it('returns the inner text of the selected component', function() {
+      expect(this.$r.text()).to.eq('Text');
+    });
+  });
+});


### PR DESCRIPTION
Adds `text` method to retrieve components' text.

Usage:

``` js
var $r = $R(component);
$r.text();
$r.find('div').text();
```
