### PR TITLE
Support React v0.13 and other goodies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "es5-shim": "^4.0.0",
     "mocha": "1",
     "mocha-phantomjs": "3",
-    "react": "^0.12.2",
+    "react": "^0.13.0",
     "sinon": "^1.12.2",
     "sinon-chai": "^2.6.0"
   }

--- a/rquery.js
+++ b/rquery.js
@@ -308,16 +308,23 @@
   };
 
   rquery.prototype.val = function (value) {
-    _.each(this.components, function(component) {
-      var node = component.getDOMNode();
+    if (value !== undefined) {
+      _.each(this.components, function(component) {
+        var node = component.getDOMNode();
 
-      if ('value' in node) {
-        node.value = value;
-        $R(component).change();
+        if ('value' in node) {
+          node.value = value;
+          $R(component).change();
+        }
+      });
+
+      return this;
+    } else {
+      if (this.components[0]) {
+        return this.components[0].getDOMNode().value;
       }
-    });
+    }
 
-    return this;
   };
 
   var EVENT_NAMES = [
@@ -365,6 +372,7 @@
     return $r;
   };
 
+  $R.rquery = rquery;
   $R.isRQuery = function (obj) {
     return obj instanceof rquery;
   };

--- a/rquery.js
+++ b/rquery.js
@@ -167,6 +167,14 @@
           return hasProp;
         });
       }
+    },
+    {
+      matcher: /^:contains\(((?:\\\)|.)*)\)/,
+      runStep: function (context, match) {
+        context.filterScope(function (component) {
+          return $R(component).text().indexOf(match[1]) !== -1;
+        });
+      }
     }
   ];
 

--- a/rquery.js
+++ b/rquery.js
@@ -331,6 +331,15 @@
     rquery.prototype[eventName] = function (eventData) {
       return this.simulateEvent(eventName, eventData);
     };
+
+    var name = 'ensure' + eventName[0].toUpperCase() + eventName.substr(1);
+    rquery.prototype[name] = function (eventData) {
+      if (this.length !== 1) {
+        throw new Error('Called ' + name + ', but current context has ' + this.length + ' components. ' + name + ' only works when 1 component is present.');
+      }
+
+      return this.simulateEvent(eventName, eventData);
+    };
   });
 
   var $R = function (components, selector) {

--- a/rquery.js
+++ b/rquery.js
@@ -54,10 +54,11 @@
       runStep: function (context, match) {
         var newScope = _(context.currentScope)
             .map(function (component) {
-              component = component._renderedComponent || component;
+              var depth = component._reactInternalInstance._rootNodeID.split('.').length;
 
               return TestUtils.findAllInRenderedTree(component, function (descendent) {
-                return descendent._mountDepth === component._mountDepth + 1;
+                var descendentDepth = descendent._reactInternalInstance._rootNodeID.split('.').length;
+                return depth + 1 === descendentDepth;
               });
             })
             .compact()
@@ -90,7 +91,10 @@
       runStep: function (context, match) {
         context.filterScope(function (component) {
           if (TestUtils.isCompositeComponent(component)) {
-            return component._currentElement.type.displayName === match[1];
+            return component._reactInternalInstance
+                && component._reactInternalInstance._currentElement
+                && component._reactInternalInstance._currentElement.type
+                && component._reactInternalInstance._currentElement.type.displayName === match[1];
           }
 
           return false;
@@ -102,7 +106,7 @@
       runStep: function (context, match) {
         context.filterScope(function (component) {
           if (TestUtils.isDOMComponent(component)) {
-            return component._tag === match[1];
+            return component.getDOMNode().tagName === match[1].toUpperCase();
           }
 
           return false;

--- a/rquery.js
+++ b/rquery.js
@@ -307,6 +307,19 @@
     }).join('');
   };
 
+  rquery.prototype.val = function (value) {
+    _.each(this.components, function(component) {
+      var node = component.getDOMNode();
+
+      if ('value' in node) {
+        node.value = value;
+        $R(component).change();
+      }
+    });
+
+    return this;
+  };
+
   var EVENT_NAMES = [
     // clipboard events
     'copy', 'cut', 'paste',

--- a/rquery.js
+++ b/rquery.js
@@ -114,7 +114,7 @@
       }
     },
     {
-      matcher: /^\.([^\s]+)/,
+      matcher: /^\.([^\s:]+)/,
       runStep: function (context, match) {
         context.filterScope(function (component) {
           if (TestUtils.isDOMComponent(component)

--- a/rquery.js
+++ b/rquery.js
@@ -289,6 +289,8 @@
     for (var i = 0; i < this.components.length; i++) {
       TestUtils.Simulate[eventName](this.components[i].getDOMNode(), eventData);
     }
+
+    return this;
   };
 
   rquery.prototype.text = function () {
@@ -319,7 +321,7 @@
 
   EVENT_NAMES.forEach(function (eventName) {
     rquery.prototype[eventName] = function (eventData) {
-      this.simulateEvent(eventName, eventData);
+      return this.simulateEvent(eventName, eventData);
     };
   });
 

--- a/test/events.spec.js
+++ b/test/events.spec.js
@@ -78,4 +78,29 @@ describe('Events', function () {
       expect(stubs.div).to.not.have.been.called;
     });
   });
+
+  describe('#ensureClick', function () {
+    describe('when 0 components are found', function () {
+      it('throws an error', function () {
+        expect(function () {
+          $R(component, 'h1').ensureClick();
+        }).to.throw('Called ensureClick, but current context has 0 components. ensureClick only works when 1 component is present.');
+      });
+    });
+
+    describe('when 2 components are found', function () {
+      it('throws an error', function () {
+        expect(function () {
+          $R(component, 'button').ensureClick();
+        }).to.throw('Called ensureClick, but current context has 2 components. ensureClick only works when 1 component is present.');
+      });
+    });
+
+    describe('when 1 component is found', function () {
+      it('clicks the component', function () {
+        $R(component, 'a').ensureClick();
+        expect(stubs.a).to.have.been.called;
+      });
+    });
+  });
 });

--- a/test/rquery.spec.js
+++ b/test/rquery.spec.js
@@ -104,7 +104,7 @@ describe('#text', function () {
 
   context('when called on multiple components', function() {
     it('returns the inner text of the selected components', function() {
-      expect(this.$r.find('p').text()).to.eq('Text');
+      expect(this.$r.text()).to.eq('Text');
     });
   });
 

--- a/test/rquery.spec.js
+++ b/test/rquery.spec.js
@@ -1,6 +1,6 @@
-describe('#findComponent', function () {
-  var TestUtils = React.addons.TestUtils;
+var TestUtils = React.addons.TestUtils;
 
+describe('#findComponent', function () {
   before(function () {
     this.reactClass = React.createClass({
       render: function () {
@@ -86,8 +86,6 @@ describe('#at', function () {
 });
 
 describe('#text', function () {
-  var TestUtils = React.addons.TestUtils;
-
   before(function () {
     this.reactClass = React.createClass({
       render: function () {
@@ -111,6 +109,51 @@ describe('#text', function () {
   context('when called on single component', function() {
     it('returns the inner text of the selected component', function() {
       expect(this.$r.text()).to.eq('Text');
+    });
+  });
+});
+
+describe('#val', function () {
+  before(function () {
+    this.spy = sinon.spy($R.rquery.prototype, 'change');
+  });
+
+  after(function () {
+    this.spy.reset();
+  });
+
+  describe('when called on an input', function () {
+    before(function () {
+      this.component = TestUtils.renderIntoDocument(React.createElement('input', { defaultValue: 'hello' }));
+      this.$r = $R(this.component);
+    });
+
+    it('returns the current value when no value passed in', function () {
+      expect(this.$r.val()).to.equal('hello');
+      expect(this.spy).to.not.have.beenCalled;
+    });
+
+    it('changes the value of the input', function () {
+      this.$r.val('world');
+      expect(this.$r.val()).to.equal('world');
+      expect(this.spy).to.have.beenCalled;
+    });
+  });
+
+  describe('when called on a non-input', function () {
+    before(function () {
+      this.component = TestUtils.renderIntoDocument(React.createElement('div', { value: 'hello' }));
+      this.$r = $R(this.component);
+    });
+
+    it('returns undefined', function () {
+      expect(this.$r.val()).to.be.undefined;
+      expect(this.spy).to.not.have.beenCalled;
+    });
+
+    it('does not change the value', function () {
+      this.$r.val('world');
+      expect(this.spy).to.not.have.beenCalled;
     });
   });
 });

--- a/test/selectors.spec.js
+++ b/test/selectors.spec.js
@@ -334,4 +334,26 @@ describe('Selectors', function () {
       expect(this.$r[0].props).to.contain.key('data-something');
     });
   });
+
+  describe(':contains() selector', function () {
+    describe('when not scoped to a specific element', function () {
+      before(function () {
+        this.$r = run(':contains(descendent)');
+      });
+
+      it('finds all components that contain the text', function () {
+        expect(this.$r).to.have.length(5);
+      });
+    });
+
+    describe('when scoped to a specific element', function () {
+      before(function () {
+        this.$r = run('div :contains(descendent)');
+      });
+
+      it('finds all scoped components that contain the text', function () {
+        expect(this.$r).to.have.length(3);
+      });
+    });
+  });
 });


### PR DESCRIPTION
- Add support for React v0.13
- Make event helpers support chaining
- Add a `:contains(text)` selector
- Add new `ensure` event helpers
- Add `.val` helper
