### PR TITLE
Fix chained class selector

### DIFF
--- a/rquery.js
+++ b/rquery.js
@@ -114,7 +114,7 @@
       }
     },
     {
-      matcher: /^\.([^\s:]+)/,
+      matcher: /^\.([^\s:.]+)/,
       runStep: function (context, match) {
         context.filterScope(function (component) {
           if (TestUtils.isDOMComponent(component)

--- a/test/selectors.spec.js
+++ b/test/selectors.spec.js
@@ -186,8 +186,22 @@ describe('Selectors', function () {
       expect(this.$r).to.have.length(1);
     });
 
-    it('first component is instance of "a" tag', function () {
+    it('first component is instance of "div" tag', function () {
       expect(this.$r[0]).to.be.componentWithTag('div');
+    });
+  });
+
+  describe('chained DOM class selector', function () {
+    before(function () {
+      this.$r = run('.my-class.some-other-class');
+    });
+
+    it('find one component', function () {
+      expect(this.$r).to.have.length(1);
+    });
+
+    it('has the correct class names', function () {
+      expect(this.$r[0]).to.have.prop('className', 'my-class some-other-class');
     });
   });
 


### PR DESCRIPTION
Previously, a chained class selector (e.g. `.class-one.class-two`) would not work as expected.
