### PR TITLE
Fix DOM matcher (React v15)

### DIFF
--- a/rquery.js
+++ b/rquery.js
@@ -72,10 +72,13 @@
     }
 
     if (isDOMComponent(component)) {
-      if (prop === 'className') {
-        return component.className;
-      } else {
-        return component.getAttribute(prop);
+      switch (prop) {
+        case 'checked':
+        case 'className':
+          return component[prop];
+
+        default:
+          return component.getAttribute(prop);
       }
     } else {
       return component.props[prop];
@@ -84,7 +87,14 @@
 
   function componentHasProp (component, prop) {
     if (isDOMComponent(component)) {
-      return component.hasAttribute(prop);
+      switch (prop) {
+        case 'checked':
+        case 'className':
+          return prop in component;
+
+        default:
+          return component.hasAttribute(prop);
+      }
     } else {
       return component.props && prop in component.props;
     }
@@ -685,6 +695,14 @@
     }
   };
 
+  rquery.prototype.disabled = function (name) {
+    if (this.length < 1) {
+      throw new Error('$R#disabled requires at least one component. No components in current scope.');
+    }
+
+    return rquery_getDOMNode(this[0]).disabled;
+  };
+
   rquery.prototype.checked = function (value) {
     this._notAllowedInShallowMode('checked');
 
@@ -700,9 +718,11 @@
 
       return this;
     } else {
-      if (this.components[0]) {
-        return rquery_getDOMNode(this.components[0]).checked;
+      if (this.length < 1) {
+        throw new Error('$R#checked requires at least one component. No components in current scope.');
       }
+
+      return rquery_getDOMNode(this[0]).checked;
     }
   };
 

--- a/rquery.js
+++ b/rquery.js
@@ -300,7 +300,13 @@
     {
       matcher: /^\.([^\s:.)!\[\]]+)/,
       matchClass: function (className, match) {
-        var classes = className.split(' ');
+        var classes;
+
+        if (window.SVGAnimatedString && className instanceof SVGAnimatedString) {
+          className = className.animVal;
+        }
+
+        classes = className.split(' ');
         return classes.indexOf(match[1]) !== -1;
       },
       runStep: function (context, match) {

--- a/rquery.js
+++ b/rquery.js
@@ -265,10 +265,10 @@
       matcher: /^([a-z]\w*)/,
       runStep: function (context, match) {
         context.filterScope(function (component) {
-          // if the component is composite, then look at its DOM node to match
-          // this allows the composite component to be kept in the context
+          // composite components must be found by their displayName, not its
+          // root DOM node,
           if (TestUtils.isCompositeComponent(component)) {
-            component = rquery_getDOMNode(component);
+            return false;
           }
 
           if (!component.tagName) {

--- a/test/rquery.spec.js
+++ b/test/rquery.spec.js
@@ -297,6 +297,41 @@ describe('#val', function () {
   });
 });
 
+describe('#disabled', function () {
+  describe('when called on a disabled input', function () {
+    before(function () {
+      this.component = TestUtils.renderIntoDocument(React.createElement('input', { disabled: true }));
+      this.$r = $R(this.component);
+    });
+
+    it('returns true', function () {
+      expect(this.$r.disabled()).to.equal(true);
+    });
+  });
+
+  describe('when called on an enabled input', function () {
+    before(function () {
+      this.component = TestUtils.renderIntoDocument(React.createElement('input', { disabled: false }));
+      this.$r = $R(this.component);
+    });
+
+    it('returns false', function () {
+      expect(this.$r.disabled()).to.equal(false);
+    });
+  });
+
+  describe('when called on a non-input', function () {
+    before(function () {
+      this.component = TestUtils.renderIntoDocument(React.createElement('div'));
+      this.$r = $R(this.component);
+    });
+
+    it('returns undefined', function () {
+      expect(this.$r.disabled()).to.be.undefined;
+    });
+  });
+});
+
 describe('#checked', function () {
   before(function () {
     this.spy = sinon.spy($R.rquery.prototype, 'change');

--- a/test/selectors.spec.js
+++ b/test/selectors.spec.js
@@ -238,21 +238,35 @@ function runSelectors (shallow) {
     });
 
     if (!shallow) {
-      describe('internal composite DOM components', function () {
+      describe('DOM components that are children of DOM components', function () {
         before(function () {
           this.$r = run('div > button');
         });
 
         it('finds the button components', function () {
-          expect(this.$r).to.have.length(3);
+          expect(this.$r).to.have.length(2);
         });
 
-        it('finds the composite component', function () {
-          expect(TestUtils.isCompositeComponentWithType(this.$r[1], ChildComponent)).to.be.true;
+        it('only matches DOM components', function () {
+          expect(this.$r.components.map(tagName)).to.be.eql(['BUTTON', 'BUTTON']);
         });
       });
 
-      it('finds composite components that are children of composite components', function () {
+      describe('composite components that are children of DOM components', function () {
+        before(function () {
+          this.$r = run('div > ChildComponent');
+        });
+
+        it('finds one component', function () {
+          expect(this.$r).to.have.length(1);
+        });
+
+        it('finds the composite component', function () {
+          expect(TestUtils.isCompositeComponentWithType(this.$r[0], ChildComponent)).to.be.true;
+        });
+      });
+
+      it('composite components that are children of composite components', function () {
         this.$r = run('MyComponent > ChildComponent');
         expect(this.$r).to.have.length(1);
       });
@@ -690,7 +704,7 @@ function runSelectors (shallow) {
       });
 
       it('finds all the descendants that do not match any of the union expressions', function () {
-        expect(this.$r).to.have.length(shallow ? 4 : 2);
+        expect(this.$r).to.have.length(shallow ? 4 : 3);
       });
 
       it('the matched children have the expected tag names', function () {
@@ -706,6 +720,7 @@ function runSelectors (shallow) {
         } else {
           expected = [
             'A',
+            undefined,
             'DIV'
           ];
         }
@@ -726,6 +741,7 @@ function runSelectors (shallow) {
         } else {
           expected = [
             'button',
+            undefined,
             undefined
           ];
         }


### PR DESCRIPTION
The DOM matcher would incorrectly match Composite components that had the same root DOM node. To match the composite component, use its `displayName`.
